### PR TITLE
Add Protocol to Zero-Knowledge Proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 - [marlin](https://github.com/scipr-lab/marlin) A Rust library for the Marlin preprocessing zkSNARK.
 - [merlin](https://github.com/dalek-cryptography/merlin) Composable proof transcripts for public-coin arguments of knowledge.
 - [OpenZKP](https://github.com/0xProject/OpenZKP) pure Rust implementations of Zero-Knowledge Proof systems.
+- [Protocol](https://github.com/name970/Protocol) Verifiable computation protocol using exact INT8 matrix multiplication (Ozaki-scheme decomposition) and a Freivalds-style audit, as the compute layer of a Proof-of-Useful-Work consensus.
 - [rust-secp256k1-zkp](https://github.com/mimblewimble/rust-secp256k1-zkp)  ZKP fork for rust-secp256k1, adds wrappers for range proofs, pedersen commitments, etc.
 - [sonic](https://github.com/ebfull/sonic) a protocol for quickly verifiable, compact zero-knowledge proofs of arbitrary computations.
 - [Spartan](https://github.com/microsoft/Spartan) High-speed zkSNARKs without trusted setup.


### PR DESCRIPTION
Adding Protocol to the Zero-Knowledge Proofs section — a verifiable computation / Proof-of-Useful-Work consensus using exact INT8 matrix multiplication (Ozaki-scheme decomposition) and a Freivalds-style audit as its compute layer. MIT licensed, public repo with CI and good-first-issue tasks.